### PR TITLE
fix(api-client): 修复API响应解析问题

### DIFF
--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -24,6 +24,20 @@ export class EpayClient {
         'Content-Type': 'application/x-www-form-urlencoded'
       }
     })
+
+    // 添加响应拦截器,处理API返回字符串的情况
+    this.axios.interceptors.response.use(response => {
+      // 如果响应数据是字符串,尝试解析为JSON
+      if (typeof response.data === 'string') {
+        try {
+          response.data = JSON.parse(response.data)
+        } catch (e) {
+          // 如果解析失败,保持原样
+          this.logger.warn('无法解析API响应为JSON:', response.data)
+        }
+      }
+      return response
+    })
   }
 
   /**


### PR DESCRIPTION
添加响应拦截器处理API返回JSON字符串的情况。
当API返回的Content-Type不是application/json时,
axios不会自动解析响应体,导致response.data为字符串而非对象。

通过拦截器自动检测并解析JSON字符串,确保后续代码能正确访问响应数据。